### PR TITLE
feat: add charts (area, line, bar)

### DIFF
--- a/src/charts.py
+++ b/src/charts.py
@@ -1,0 +1,32 @@
+import streamlit as st
+
+
+DEFAULT_TYPE = 0
+CHART_FUNCTIONS = [
+    {"label": "Table", "func": st.dataframe},
+    {"label": "Line Chart", "func": st.line_chart},
+    {"label": "Area Chart", "func": st.area_chart},
+    {"label": "Bar Chart", "func": st.bar_chart},
+]
+
+
+def render_data(data, key):
+    def set_type(i):
+        data["type"] = i
+
+    columns = st.columns(len(CHART_FUNCTIONS))
+    # render chart type buttons
+    for i, column in enumerate(columns):
+        with column:
+            label = CHART_FUNCTIONS[i]["label"]
+            key = f"b_{key}_type_{i}"
+            st.button(
+                label,
+                key=key,
+                on_click=set_type,
+                args=[i],
+            )
+    # render chart
+    type = data.get("type", DEFAULT_TYPE)
+    func = CHART_FUNCTIONS[type]["func"]
+    func(data["data"])

--- a/src/frosty_app.py
+++ b/src/frosty_app.py
@@ -1,6 +1,7 @@
 import openai
 import re
 import streamlit as st
+from charts import render_data
 from prompts import get_system_prompt
 
 st.title("☃️ Frosty")
@@ -17,13 +18,13 @@ if prompt := st.chat_input():
     st.session_state.messages.append({"role": "user", "content": prompt})
 
 # display the existing chat messages
-for message in st.session_state.messages:
+for i, message in enumerate(st.session_state.messages):
     if message["role"] == "system":
         continue
     with st.chat_message(message["role"]):
         st.write(message["content"])
         if "results" in message:
-            st.dataframe(message["results"])
+            render_data(key=i, data=message["results"])
 
 # If last message is not from assistant, we need to generate a new response
 if st.session_state.messages[-1]["role"] != "assistant":
@@ -44,6 +45,6 @@ if st.session_state.messages[-1]["role"] != "assistant":
         if sql_match:
             sql = sql_match.group(1)
             conn = st.experimental_connection("snowpark")
-            message["results"] = conn.query(sql)
-            st.dataframe(message["results"])
+            message["results"] = {"data": conn.query(sql)}
+            render_data(key=len(st.session_state.messages), data=message["results"])
         st.session_state.messages.append(message)


### PR DESCRIPTION
- replaces the result table with a widget that can render the data in four different styles: table (current behavior) or as a chart (area, line, or bar)
- table is the default style